### PR TITLE
Use &Path over &PathBuf

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod wrapped;
 use std::fs::{File, OpenOptions, Permissions};
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::Path;
 use std::{env, fs};
 
 use chrono::Utc;
@@ -29,7 +29,7 @@ fn default_env(key: &str, value: &str) {
 	}
 }
 
-fn overwrite_file(path: &PathBuf, content: &[u8]) {
+fn overwrite_file(path: &Path, content: &[u8]) {
 	let mut file = OpenOptions::new()
 		.create(true)
 		.write(true)
@@ -44,7 +44,7 @@ fn overwrite_file(path: &PathBuf, content: &[u8]) {
 	});
 }
 
-fn ensure_script(path: &PathBuf, content: &[u8]) {
+fn ensure_script(path: &Path, content: &[u8]) {
 	if !path.exists() {
 		let mut file = OpenOptions::new()
 			.create(true)
@@ -62,7 +62,7 @@ fn ensure_script(path: &PathBuf, content: &[u8]) {
 	}
 }
 
-fn overwrite_script(path: &PathBuf, content: &[u8]) {
+fn overwrite_script(path: &Path, content: &[u8]) {
 	overwrite_file(path, content);
 	fs::set_permissions(path, Permissions::from_mode(0o755))
 		.unwrap_or_else(|e| panic!("Failed to set permissions for {:?}, {}", path, e));

--- a/src/srcinfo_to_pkgbuild.rs
+++ b/src/srcinfo_to_pkgbuild.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use srcinfo::{ArchVec, Srcinfo};
 
@@ -31,9 +31,9 @@ fn push_arrays(pkgbuild: &mut String, key: &str, arch_values: &[ArchVec]) {
 	}
 }
 
-pub fn static_pkgbuild(path: PathBuf) -> String {
-	let srcinfo = Srcinfo::parse_file(&path)
-		.unwrap_or_else(|e| panic!("{}:{} Failed to parse {:?}, {}", file!(), line!(), &path, e));
+pub fn static_pkgbuild(path: &Path) -> String {
+	let srcinfo = Srcinfo::parse_file(path)
+		.unwrap_or_else(|e| panic!("{}:{} Failed to parse {:?}, {}", file!(), line!(), path, e));
 	let mut pkgbuild = String::new();
 
 	push_field(&mut pkgbuild, "pkgname", "tmp");

--- a/src/tar_check.rs
+++ b/src/tar_check.rs
@@ -2,12 +2,12 @@ use crate::util;
 
 use std::fs::File;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::Path;
 
 use tar::*;
 use xz2::read::XzDecoder;
 
-pub fn tar_check(tar_file: &PathBuf) {
+pub fn tar_check(tar_file: &Path) {
 	let tar_str = tar_file
 		.to_str()
 		.unwrap_or_else(|| panic!("{}:{} Failed to parse tar file name", file!(), line!()));

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -34,7 +34,7 @@ fn download_srcinfo_sources(dirs: &ProjectDirs) {
 	let srcinfo_path = Path::new(".SRCINFO")
 		.canonicalize()
 		.unwrap_or_else(|e| panic!("Cannot resolve .SRCINFO path in {}, {}", dir, e));
-	file.write_all(crate::srcinfo_to_pkgbuild::static_pkgbuild(srcinfo_path).as_bytes())
+	file.write_all(crate::srcinfo_to_pkgbuild::static_pkgbuild(&srcinfo_path).as_bytes())
 		.expect("cannot write to PKGBUILD.static");
 	eprintln!("Downloading sources using .SRCINFO...");
 	let command = wrap_yes_internet(dirs)


### PR DESCRIPTION
like str and String, Path and Pathbuf are borrowed/owned counterparts.
&Path should always be used over &Pathbuf.

This is based on #23 so the diff is a mess right now. Merge that first before reviewing this.