### PR TITLE
Implement naive devel upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ RUA will thus interrupt you 3 times, not 7 as if it would be plainly recursive. 
 * This tool focuses on AUR packages only, you cannot `-Suy` your system with it. Use pacman for that.
 * Optional dependencies (optdepends) are not installed. They are skipped. Check them out manually when you review PKGBUILD.
 * The tool does not handle versions. It will always install the latest version possible, and it will always assume that latest version is enough.
-* "-git" packages do not receive automatic upgrades yet. Merge requests welcomed.
+* Development packages such as "-git" packages are only rebuilt when running `rua upgrade --devel`. No version checks are done to avoid unnecessary rebuilds. Merge requests welcomed.
 * Unless you explicitly enable it, builds do not share user home (~). This may result in maven/npm/cargo/whatever re-downloading dependencies with each build. If you want to override some of that, take a look at ~/.config/rua/wrap_args.d/ and the parent directory for examples.
 
 

--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -12,7 +12,10 @@ use prettytable::format::*;
 use prettytable::*;
 use std::collections::HashSet;
 
-pub fn upgrade(dirs: &ProjectDirs) {
+pub fn upgrade(dirs: &ProjectDirs, devel: bool) {
+	if devel {
+		unimplemented!("--devel support to be added");
+	}
 	let alpm = pacman::create_alpm();
 	let pkg_cache = alpm
 		.localdb()

--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -7,15 +7,22 @@ use alpm::Version;
 use colored::*;
 use directories::ProjectDirs;
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use log::debug;
 use prettytable::format::*;
 use prettytable::*;
+use regex::Regex;
 use std::collections::HashSet;
 
-pub fn upgrade(dirs: &ProjectDirs, devel: bool) {
-	if devel {
-		unimplemented!("--devel support to be added");
+fn pkg_is_devel(name: &str) -> bool {
+	lazy_static! {
+		// make sure that the --devel help string in cli_args.rs matches if you change this
+		static ref RE: Regex = Regex::new(r"-(git|hg|bzr|svn|cvs|darcs)(-.+)*$").unwrap();
 	}
+	RE.is_match(name)
+}
+
+pub fn upgrade(dirs: &ProjectDirs, devel: bool) {
 	let alpm = pacman::create_alpm();
 	let pkg_cache = alpm
 		.localdb()
@@ -46,7 +53,7 @@ pub fn upgrade(dirs: &ProjectDirs, devel: bool) {
 	for (pkg, local_ver) in aur_pkgs {
 		let raur_ver = info_map.get(pkg).map(|p| p.version.to_string());
 		if let Some(raur_ver) = raur_ver {
-			if local_ver < Version::new(&raur_ver) {
+			if local_ver < Version::new(&raur_ver) || (devel && pkg_is_devel(pkg)) {
 				outdated.push((pkg, local_ver.to_string(), raur_ver));
 			} else {
 				up_to_date.push(pkg);

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -76,7 +76,11 @@ pub enum Action {
 	},
 	#[structopt(about = "Upgrade AUR packages")]
 	Upgrade {
-		#[structopt(long, help = "Also rebuild all *-git packages")]
+		#[structopt(
+			long,
+			help = "Also rebuild all development packages.
+Supported: git, hg, bzr, svn, cvs, darcs"
+		)]
 		devel: bool,
 	},
 }

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -75,5 +75,8 @@ pub enum Action {
 		target: PathBuf,
 	},
 	#[structopt(about = "Upgrade AUR packages")]
-	Upgrade {},
+	Upgrade {
+		#[structopt(long, help = "Also rebuild all *-git packages")]
+		devel: bool,
+	},
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,8 +97,8 @@ fn main() {
 			);
 			eprintln!("Finished checking pachage: {:?}", target);
 		}
-		Action::Upgrade {} => {
-			action_upgrade::upgrade(&dirs);
+		Action::Upgrade { devel } => {
+			action_upgrade::upgrade(&dirs, devel);
 		}
 	};
 }


### PR DESCRIPTION
This is a feature I really need at least in a basic form. My implementation just considers all packages named `*-git` outdated during upgrade if a `--devel` -flag is passed.