### PR TITLE
implement more reliable separation of command types

### DIFF
--- a/src/action_builddir.rs
+++ b/src/action_builddir.rs
@@ -1,8 +1,9 @@
-use crate::{tar_check, wrapped};
-use directories::ProjectDirs;
+use crate::rua_files::RuaDirs;
+use crate::tar_check;
+use crate::wrapped;
 use std::path::PathBuf;
 
-pub fn action_builddir(offline: bool, dir: PathBuf, dirs: &ProjectDirs) {
+pub fn action_builddir(offline: bool, dir: PathBuf, dirs: &RuaDirs) {
 	let dir = dir
 		.canonicalize()
 		.unwrap_or_else(|err| panic!("Cannot canonicalize path {:?}, {}", dir, err));

--- a/src/action_install.rs
+++ b/src/action_install.rs
@@ -54,12 +54,14 @@ fn show_install_summary(pacman_deps: &IndexSet<String>, aur_packages: &IndexMap<
 	if pacman_deps.len() + aur_packages.len() == 1 {
 		return;
 	}
-	eprintln!("\nIn order to install all targets, the following pacman packages will need to be installed:");
-	eprintln!(
-		"{}",
-		pacman_deps.iter().map(|s| format!("  {}", s)).join("\n")
-	);
-	eprintln!("And the following AUR packages will need to be built and installed:");
+	if !pacman_deps.is_empty() {
+		eprintln!("\nIn order to install all targets, the following pacman packages will need to be installed:");
+		eprintln!(
+			"{}",
+			pacman_deps.iter().map(|s| format!("  {}", s)).join("\n")
+		);
+	};
+	eprintln!("\nAnd the following AUR packages will need to be built and installed:");
 	let mut aur_packages = aur_packages.iter().collect::<Vec<_>>();
 	aur_packages.sort_by_key(|pair| -*pair.1);
 	for (aur, dep) in &aur_packages {

--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -2,10 +2,10 @@ use crate::action_install;
 use crate::aur_rpc_utils;
 use crate::pacman;
 use crate::print_package_table;
+use crate::rua_files::RuaDirs;
 use crate::terminal_util;
 use alpm::Version;
 use colored::*;
-use directories::ProjectDirs;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use log::debug;
@@ -22,7 +22,7 @@ fn pkg_is_devel(name: &str) -> bool {
 	RE.is_match(name)
 }
 
-pub fn upgrade(dirs: &ProjectDirs, devel: bool) {
+pub fn upgrade(dirs: &RuaDirs, devel: bool) {
 	let alpm = pacman::create_alpm();
 	let pkg_cache = alpm
 		.localdb()

--- a/src/reviewing.rs
+++ b/src/reviewing.rs
@@ -1,12 +1,11 @@
 use crate::git_utils;
-use crate::rua_files;
+use crate::rua_files::RuaDirs;
 use crate::terminal_util;
 use crate::wrapped;
-use directories::ProjectDirs;
 use log::debug;
 use std::path::Path;
 
-pub fn review_repo(dir: &Path, pkgbase: &str, dirs: &ProjectDirs) {
+pub fn review_repo(dir: &Path, pkgbase: &str, dirs: &RuaDirs) {
 	let mut dir_contents = dir.read_dir().unwrap_or_else(|err| {
 		panic!(
 			"{}:{} Failed to read directory for reviewing, {}",
@@ -23,7 +22,7 @@ pub fn review_repo(dir: &Path, pkgbase: &str, dirs: &ProjectDirs) {
 		git_utils::fetch(&dir);
 	}
 
-	let build_dir = rua_files::build_dir(dirs, pkgbase);
+	let build_dir = dirs.build_dir(pkgbase);
 	if build_dir.exists() && git_utils::is_upstream_merged(&dir) {
 		eprintln!("WARNING: your AUR repo is up-to-date.");
 		eprintln!(

--- a/src/rua_environment.rs
+++ b/src/rua_environment.rs
@@ -1,65 +1,19 @@
-use crate::rua_files;
-use crate::wrapped;
+use crate::cli_args::CLIColorType;
+use crate::cli_args::CliArgs;
 use chrono::Utc;
-use directories::ProjectDirs;
 use env_logger::Env;
 use log::debug;
 use std::env;
-use std::fs;
-use std::fs::{OpenOptions, Permissions};
 use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-use std::process::exit;
-use std::process::Command;
 
-fn set_env_if_not_set(key: &str, value: &str) {
+pub fn set_env_if_not_set(key: &str, value: &str) {
 	if env::var_os(key).is_none() {
 		env::set_var(key, value);
 	}
 }
 
-fn overwrite_file(path: &Path, content: &[u8]) {
-	let mut file = OpenOptions::new()
-		.create(true)
-		.write(true)
-		.truncate(true)
-		.open(path)
-		.unwrap_or_else(|err| panic!("Failed to overwrite (initialize) file {:?}, {}", path, err));
-	file.write_all(content).unwrap_or_else(|e| {
-		panic!(
-			"Failed to write to file {:?} during initialization, {}",
-			path, e
-		)
-	});
-}
-
-fn ensure_script(path: &Path, content: &[u8]) {
-	if !path.exists() {
-		let mut file = OpenOptions::new()
-			.create(true)
-			.write(true)
-			.open(path)
-			.unwrap_or_else(|e| panic!("Failed to overwrite (initialize) file {:?}, {}", path, e));
-		file.write_all(content).unwrap_or_else(|e| {
-			panic!(
-				"Failed to write to file {:?} during initialization, {}",
-				path, e
-			)
-		});
-		fs::set_permissions(path, Permissions::from_mode(0o755))
-			.unwrap_or_else(|e| panic!("Failed to set permissions for {:?}, {}", path, e));
-	}
-}
-
-fn overwrite_script(path: &Path, content: &[u8]) {
-	overwrite_file(path, content);
-	fs::set_permissions(path, Permissions::from_mode(0o755))
-		.unwrap_or_else(|e| panic!("Failed to set permissions for {:?}, {}", path, e));
-}
-
 // sets environment and other things applicable to all RUA commands
-pub fn prepare_environment(dirs: &ProjectDirs) {
+pub fn prepare_environment(config: &CliArgs) {
 	env_logger::Builder::from_env(Env::default().filter_or("LOG_LEVEL", "info"))
 		.format(|buf, record| {
 			writeln!(
@@ -71,16 +25,29 @@ pub fn prepare_environment(dirs: &ProjectDirs) {
 			)
 		})
 		.init();
+	match config.color {
+		// see "colored" crate and referenced specs
+		CLIColorType::auto => {
+			env::remove_var("NOCOLOR");
+			env::remove_var("CLICOLOR_FORCE");
+			env::remove_var("CLICOLOR");
+		}
+		CLIColorType::never => {
+			env::set_var("NOCOLOR", "1");
+			env::remove_var("CLICOLOR_FORCE");
+			env::set_var("CLICOLOR", "0");
+		}
+		CLIColorType::always => {
+			env::remove_var("NOCOLOR");
+			env::set_var("CLICOLOR_FORCE", "1");
+			env::remove_var("CLICOLOR");
+		}
+	}
 	debug!(
 		"{} version {}",
 		env!("CARGO_PKG_NAME"),
 		env!("CARGO_PKG_VERSION")
 	);
-	if users::get_current_uid() == 0 {
-		eprintln!("RUA does not allow building as root.");
-		eprintln!("Also, makepkg will not allow you building as root anyway.");
-		exit(1)
-	}
 	assert!(
 		env::var_os("PKGDEST").is_none(),
 		"Cannot work with PKGDEST environment being set. Please run RUA without it"
@@ -103,47 +70,4 @@ pub fn prepare_environment(dirs: &ProjectDirs) {
 	} else {
 		env::set_var("PKGEXT", ".pkg.tar.xz");
 	};
-	if !Command::new("bwrap")
-		.args(&["--ro-bind", "/", "/", "true"])
-		.status()
-		.expect("bwrap binary not found. RUA uses bubblewrap for security isolation.")
-		.success()
-	{
-		eprintln!("Failed to run bwrap.");
-		eprintln!("A possible cause for this is if RUA itself is run in jail (docker, bwrap, firejail,..).");
-		eprintln!("If so, see https://github.com/vn971/rua/issues/8");
-		exit(4)
-	}
-	std::fs::create_dir_all(dirs.cache_dir()).expect("Failed to create project cache directory");
-	rm_rf::force_remove_all(dirs.config_dir().join(".system")).ok();
-	std::fs::create_dir_all(dirs.config_dir().join(".system"))
-		.expect("Failed to create project config directory");
-	std::fs::create_dir_all(dirs.config_dir().join("wrap_args.d"))
-		.expect("Failed to create project config directory");
-	overwrite_file(
-		&dirs.config_dir().join(".system/seccomp-i686.bpf"),
-		rua_files::SECCOMP_I686,
-	);
-	overwrite_file(
-		&dirs.config_dir().join(".system/seccomp-x86_64.bpf"),
-		rua_files::SECCOMP_X86_64,
-	);
-	let seccomp_path = format!(
-		".system/seccomp-{}.bpf",
-		uname::uname()
-			.expect("Failed to get system architecture via uname")
-			.machine
-	);
-	set_env_if_not_set(
-		"RUA_SECCOMP_FILE",
-		dirs.config_dir().join(seccomp_path).to_str().unwrap(),
-	);
-	overwrite_script(
-		&dirs.config_dir().join(wrapped::WRAP_SCRIPT_PATH),
-		rua_files::WRAP_SH,
-	);
-	ensure_script(
-		&dirs.config_dir().join(".system/wrap_args.sh.example"),
-		rua_files::WRAP_ARGS_EXAMPLE,
-	);
 }

--- a/src/rua_files.rs
+++ b/src/rua_files.rs
@@ -1,27 +1,145 @@
+use crate::rua_environment;
+use crate::wrapped;
 use directories::ProjectDirs;
+use fs2::FileExt;
+use std::fs;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::fs::Permissions;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::path::PathBuf;
+use std::process::exit;
 
-/// subdirectory of ~/.config/rua where the package is reviewed by user, and changes are kept
-pub fn global_review_dir(dirs: &ProjectDirs) -> PathBuf {
-	dirs.config_dir().join("pkg")
+pub struct RuaDirs {
+	/// Subdirectory of ~/.cache/rua where packages are built after review
+	pub global_build_dir: PathBuf,
+	/// Subdirectory of ~/.config/rua where the package is reviewed by user, and changes are kept
+	global_review_dir: PathBuf,
+	/// Directory where built and user-reviewed package artifacts are stored
+	global_checked_tars_dir: PathBuf,
+	/// Script used to wrap `makepkg` and related commands
+	pub wrapper_bwrap_script: PathBuf,
+	/// Global lock to prevent concurrent access to project dirs
+	_global_lock: File,
 }
 
-pub fn review_dir(dirs: &ProjectDirs, pkgbase: &str) -> PathBuf {
-	global_review_dir(dirs).join(pkgbase)
+impl RuaDirs {
+	pub fn new() -> RuaDirs {
+		let dirs = ProjectDirs::from("com.gitlab", "vn971", "rua")
+			.expect("Failed to determine XDG directories");
+		std::fs::create_dir_all(dirs.cache_dir())
+			.expect("Failed to create project cache directory");
+		rm_rf::force_remove_all(dirs.config_dir().join(".system")).ok();
+		std::fs::create_dir_all(dirs.config_dir().join(".system"))
+			.expect("Failed to create project config directory");
+		std::fs::create_dir_all(dirs.config_dir().join("wrap_args.d"))
+			.expect("Failed to create project config directory");
+		overwrite_file(
+			&dirs.config_dir().join(".system/seccomp-i686.bpf"),
+			SECCOMP_I686,
+		);
+		overwrite_file(
+			&dirs.config_dir().join(".system/seccomp-x86_64.bpf"),
+			SECCOMP_X86_64,
+		);
+		let seccomp_path = format!(
+			".system/seccomp-{}.bpf",
+			uname::uname()
+				.expect("Failed to get system architecture via uname")
+				.machine
+		);
+		rua_environment::set_env_if_not_set(
+			"RUA_SECCOMP_FILE",
+			dirs.config_dir().join(seccomp_path).to_str().unwrap(),
+		);
+		overwrite_script(&dirs.config_dir().join(WRAP_SCRIPT_PATH), WRAP_SH);
+		ensure_script(
+			&dirs.config_dir().join(".system/wrap_args.sh.example"),
+			WRAP_ARGS_EXAMPLE,
+		);
+		if users::get_current_uid() == 0 {
+			eprintln!("RUA does not allow building as root.");
+			eprintln!("Also, makepkg will not allow you building as root anyway.");
+			exit(1)
+		}
+		wrapped::check_bubblewrap_runnable();
+		let locked_file = File::open(dirs.config_dir()).unwrap_or_else(|err| {
+			panic!(
+				"Failed to open config dir {:?} for locking, {}",
+				dirs.config_dir(),
+				err
+			);
+		});
+		locked_file.try_lock_exclusive().unwrap_or_else(|_| {
+			eprintln!("Another RUA instance already running.");
+			std::process::exit(2)
+		});
+		RuaDirs {
+			global_build_dir: dirs.cache_dir().join("build"),
+			global_review_dir: dirs.config_dir().join("pkg"),
+			global_checked_tars_dir: dirs.cache_dir().join("checked_tars"),
+			wrapper_bwrap_script: dirs.config_dir().join(WRAP_SCRIPT_PATH),
+			_global_lock: locked_file,
+		}
+	}
+
+	/// Same as `global_review_dir`, but for a specific pkgbase
+	pub fn review_dir(&self, pkgbase: &str) -> PathBuf {
+		self.global_review_dir.join(pkgbase)
+	}
+
+	/// Same as `global_build_dir`, but for a specific pkgbase
+	pub fn build_dir(&self, pkgbase: &str) -> PathBuf {
+		self.global_build_dir.join(pkgbase)
+	}
+
+	/// Same as `global_checked_tars_dir`, but for a specific pkgbase
+	pub fn checked_tars_dir(&self, pkg_name: &str) -> PathBuf {
+		self.global_checked_tars_dir
+			.join("checked_tars")
+			.join(pkg_name)
+	}
 }
 
-/// Directory where packages are built after review
-pub fn global_build_dir(dirs: &ProjectDirs) -> PathBuf {
-	dirs.cache_dir().join("build")
+fn overwrite_file(path: &Path, content: &[u8]) {
+	let mut file = OpenOptions::new()
+		.create(true)
+		.write(true)
+		.truncate(true)
+		.open(path)
+		.unwrap_or_else(|err| panic!("Failed to overwrite (initialize) file {:?}, {}", path, err));
+	file.write_all(content).unwrap_or_else(|e| {
+		panic!(
+			"Failed to write to file {:?} during initialization, {}",
+			path, e
+		)
+	});
 }
 
-pub fn build_dir(dirs: &ProjectDirs, pkg_name: &str) -> PathBuf {
-	global_build_dir(dirs).join(pkg_name)
+fn ensure_script(path: &Path, content: &[u8]) {
+	if !path.exists() {
+		let mut file = OpenOptions::new()
+			.create(true)
+			.write(true)
+			.open(path)
+			.unwrap_or_else(|e| panic!("Failed to overwrite (initialize) file {:?}, {}", path, e));
+		file.write_all(content).unwrap_or_else(|e| {
+			panic!(
+				"Failed to write to file {:?} during initialization, {}",
+				path, e
+			)
+		});
+		fs::set_permissions(path, Permissions::from_mode(0o755))
+			.unwrap_or_else(|e| panic!("Failed to set permissions for {:?}, {}", path, e));
+	}
 }
 
-/// Directory where built and user-reviewed package artifacts are stored,
-pub fn checked_tars_dir(dirs: &ProjectDirs, pkg_name: &str) -> PathBuf {
-	dirs.cache_dir().join("checked_tars").join(pkg_name)
+fn overwrite_script(path: &Path, content: &[u8]) {
+	overwrite_file(path, content);
+	fs::set_permissions(path, Permissions::from_mode(0o755))
+		.unwrap_or_else(|e| panic!("Failed to set permissions for {:?}, {}", path, e));
 }
 
 pub const SHELLCHECK_WRAPPER_BYTES: &str = include_str!("../res/shellcheck-wrapper");
@@ -29,3 +147,5 @@ pub const SECCOMP_I686: &[u8] = include_bytes!("../res/seccomp-i686.bpf");
 pub const SECCOMP_X86_64: &[u8] = include_bytes!("../res/seccomp-x86_64.bpf");
 pub const WRAP_SH: &[u8] = include_bytes!("../res/wrap.sh");
 pub const WRAP_ARGS_EXAMPLE: &[u8] = include_bytes!("../res/wrap_args.sh.example");
+
+pub const WRAP_SCRIPT_PATH: &str = ".system/wrap.sh";


### PR DESCRIPTION
this should allow running "safe" actions from root user,
e.g. `rua search something`, but at the same time
forbid running `rua install something` as root.

The program-s lock is now held together with `RuaDirs` object,
which should make locking more reliable and natural.