### PR TITLE
Update rm_rf version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "rm_rf"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "stacker 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1162,7 +1162,7 @@ dependencies = [
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raur 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rm_rf 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rm_rf 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "srcinfo 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2011,7 +2011,7 @@ dependencies = [
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum rgb 0.8.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
-"checksum rm_rf 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c608efc6897cebb8c28aa9b7d37fc681d6f92478c5cc8afc8ede102f6aeddc07"
+"checksum rm_rf 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fb645949d9bd0522699c72b67751a90f12d1db36752ef24ae3cf31ae00aa44ae"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rua"
-version = "0.14.16"
+version = "0.14.17"
 description = "Secure jailed AUR helper for Arch Linux"
 authors = [
   "Vasili Novikov <n1dr+cm3513git@yandex.ru>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4.8"
 prettytable-rs = "0.8.0"
 raur = { version = "2.0.1", default-features = false, features = ["rustls"] }
 regex = "1.3.1"
-rm_rf = "0.3.0"
+rm_rf = "0.4.1"
 srcinfo = "0.3.2"
 structopt = "0.3.3"
 tar = "0.4.26"


### PR DESCRIPTION
Version 0.3.0 of `rm_rf` seems to of had a bug and wouldn't properly delete directories. This caused a bug when trying to empty the build directory in `.cache`. Updating the package seems to address this problem. This should address issue #81 