### PR TITLE
implement --printonly flag for `rua upgrade`

### DIFF
--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -74,16 +74,16 @@ pub fn upgrade(dirs: &RuaDirs, devel: bool, printonly: bool) {
 		debug!("You have the following packages outside of main repos installed:");
 		debug!("{}", aur_pkgs_string);
 		debug!("");
-		if outdated.is_empty() {
+		if outdated.is_empty() && unexistent.is_empty() {
 			eprintln!("Good job! All AUR packages are up-to-date.");
 		} else {
 			print_outdated(&outdated, &unexistent);
 			eprintln!();
-			let outdated: Vec<String> = outdated.iter().map(|o| o.0.to_string()).collect();
 			loop {
 				eprint!("Do you wish to upgrade them? [O]=ok, [X]=exit. ");
 				let string = terminal_util::read_line_lowercase();
 				if string == "o" {
+					let outdated: Vec<String> = outdated.iter().map(|o| o.0.to_string()).collect();
 					action_install::install(&outdated, dirs, false, true);
 					break;
 				} else if string == "x" {

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -85,7 +85,9 @@ Sources are downloaded using .SRCINFO only"
 		#[structopt(help = "Archive to check", required = true)]
 		target: PathBuf,
 	},
-	#[structopt(about = "Upgrade AUR packages")]
+	#[structopt(
+		about = "Upgrade AUR packages. To ignore upgrade proposals for a certain package, add it to IgnorePkg in pacman.conf"
+	)]
 	Upgrade {
 		#[structopt(
 			long = "devel",
@@ -94,6 +96,11 @@ Sources are downloaded using .SRCINFO only"
 Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 		)]
 		devel: bool,
+		#[structopt(
+			long = "printonly",
+			help = "Print the list of outdated packages to stdout, delimited by newline. Don't upgrade anything, don't ask questions (for use in scripts)."
+		)]
+		printonly: bool,
 	},
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,9 +71,9 @@ fn main() {
 			);
 			eprintln!("Finished checking package: {:?}", target);
 		}
-		Action::Upgrade { devel } => {
+		Action::Upgrade { devel, printonly } => {
 			let dirs = rua_files::RuaDirs::new();
-			action_upgrade::upgrade(&dirs, *devel);
+			action_upgrade::upgrade(&dirs, *devel, *printonly);
 		}
 	};
 }


### PR DESCRIPTION
fixes GH-86

```txt
rua upgrade --help

rua-upgrade 0.14.18
Upgrade AUR packages. To ignore upgrade proposals for a certain package, add it to IgnorePkg in pacman.conf

USAGE:
    rua upgrade [FLAGS]

FLAGS:
    -d, --devel        Also rebuild development packages.
                       Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only.
    -h, --help         Prints help information
        --printonly    Print the list of outdated packages to stdout, delimited by newline. Don't upgrade anything,
                       don't ask questions (for use in scripts).
    -V, --version      Prints version information
```