### PR TITLE
Deduplicate info code

### DIFF
--- a/src/aur_rpc_utils.rs
+++ b/src/aur_rpc_utils.rs
@@ -72,7 +72,9 @@ pub fn recursive_info(
 	Ok((info_map, pacman_deps, depth_map))
 }
 
-pub fn info_map(packages_to_query: &[&str]) -> Result<IndexMap<String, Package>, raur::Error> {
+pub fn info_map<S: AsRef<str>>(
+	packages_to_query: &[S],
+) -> Result<IndexMap<String, Package>, raur::Error> {
 	let mut result = IndexMap::new();
 	for group in packages_to_query.chunks(BATCH_SIZE) {
 		let group_info = raur::info(group)?;

--- a/src/aur_rpc_utils.rs
+++ b/src/aur_rpc_utils.rs
@@ -72,6 +72,11 @@ pub fn recursive_info(
 	Ok((info_map, pacman_deps, depth_map))
 }
 
+/// Queries the AUR for the provided given package names and returns a map all packages
+/// that match.
+///
+/// # Arguments
+/// * `packages_to_query` - A slice of package names to find in the AUR
 pub fn info_map<S: AsRef<str>>(
 	packages_to_query: &[S],
 ) -> Result<IndexMap<String, Package>, raur::Error> {

--- a/src/print_package_info.rs
+++ b/src/print_package_info.rs
@@ -1,24 +1,17 @@
+use crate::aur_rpc_utils::info_map;
 use crate::print_format::{date, opt, print_indent};
 
 use colored::*;
 use failure::Error;
-use std::collections::HashMap;
 use term_size::dimensions_stdout;
 
 pub fn info(pkgs: &[String], verbose: bool) -> Result<(), Error> {
-	let mut hm = HashMap::with_capacity(pkgs.len());
+	let pkg_map = info_map(&pkgs)?;
 
-	for chunk in pkgs.chunks(150) {
-		let pkgs = raur::info(&chunk)?;
-		for pkg in pkgs {
-			hm.insert(pkg.name.clone(), pkg);
-		}
-	}
-
-	let mut all_pkgs = Vec::with_capacity(hm.len());
+	let mut all_pkgs = Vec::with_capacity(pkg_map.len());
 
 	for pkg in pkgs {
-		if let Some(pkg) = hm.get(pkg) {
+		if let Some(pkg) = pkg_map.get(pkg) {
 			all_pkgs.push(pkg)
 		} else {
 			eprintln!("{} package '{}' was not found", "error:".red(), pkg);

--- a/src/print_package_info.rs
+++ b/src/print_package_info.rs
@@ -11,8 +11,8 @@ pub fn info(pkgs: &[String], verbose: bool) -> Result<(), Error> {
 	let mut all_pkgs = Vec::with_capacity(pkg_map.len());
 
 	for pkg in pkgs {
-		if let Some(pkg) = pkg_map.get(pkg) {
-			all_pkgs.push(pkg)
+		if let Some(found_pkg) = pkg_map.get(pkg) {
+			all_pkgs.push(found_pkg)
 		} else {
 			eprintln!("{} package '{}' was not found", "error:".red(), pkg);
 		}


### PR DESCRIPTION
Addresses #73, removing the `raur::info` call at the top of the function and using `aur_rpc_utils::info_map` instead.

This includes a modification to the `info_map` arguments. This change more closely matches the signature of `raur::info` and allows both `&[String]` and `&[&str]` to be passed to it.