### PR TITLE
Build `./` dir by default with rua builddir

### DIFF
--- a/src/action_builddir.rs
+++ b/src/action_builddir.rs
@@ -3,12 +3,20 @@ use crate::rua_environment;
 use crate::rua_files::RuaDirs;
 use crate::tar_check;
 use crate::wrapped;
-use std::path::Path;
+use std::path::{PathBuf, Path};
 
-pub fn action_builddir(dir: &Path, dirs: &RuaDirs, offline: bool, force: bool) {
-	let dir = dir
+pub fn action_builddir(dir: &Option<PathBuf>, dirs: &RuaDirs, offline: bool, force: bool) {
+	// Set `.` as default dir in case no build directory is provided.
+	let direc_param = {
+		match dir {
+			Some(path) => &path,
+			None => Path::new("."),
+		}
+	};
+
+	let dir = direc_param
 		.canonicalize()
-		.unwrap_or_else(|err| panic!("Cannot canonicalize path {:?}, {}", dir, err));
+		.unwrap_or_else(|err| panic!("Cannot canonicalize path {:?}, {}", direc_param, err));
 	let dir_str = dir
 		.to_str()
 		.unwrap_or_else(|| panic!("{}:{} Cannot parse CLI target directory", file!(), line!()));

--- a/src/action_builddir.rs
+++ b/src/action_builddir.rs
@@ -3,7 +3,7 @@ use crate::rua_environment;
 use crate::rua_files::RuaDirs;
 use crate::tar_check;
 use crate::wrapped;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 pub fn action_builddir(dir: &Option<PathBuf>, dirs: &RuaDirs, offline: bool, force: bool) {
 	// Set `.` as default dir in case no build directory is provided.

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -65,8 +65,8 @@ Sources are downloaded using .SRCINFO only"
 			help = "use --force option with makepkg, see makepkg(8)"
 		)]
 		force: bool,
-		#[structopt(help = "Target directory", required = true)]
-		target: PathBuf,
+		#[structopt(help = "Target directory")]
+		target: Option<PathBuf>,
 	},
 	#[structopt(about = "Opens AUR web search page")]
 	Search {


### PR DESCRIPTION
Closes #96 

- Removed `required ` property of `target`
attribute in `Action` enum.
- Set `target` as `Option<PathBuf> instead of
`PathBuf`.

The target dir can now be `None` if nothing is set
on cmd or `Some(path)` if it is.

- `action_builddir` now matches first the Option
and sets the `dir` to use as "./" if it was not
specified on the cmd attributes.