### PR TITLE
[WIP] Dependencies tree view for pacman and AUR packets

### DIFF
--- a/src/action_install.rs
+++ b/src/action_install.rs
@@ -250,3 +250,11 @@ pub fn check_tars_and_move(name: &str, dirs: &RuaDirs, archive_whitelist: &Index
 		});
 	}
 }
+
+fn indent_n(n: usize) -> String {
+	let mut ind = String::new();
+	for _ in 0..n {
+		ind.push_str("\t");
+	}
+	ind
+}

--- a/src/action_install.rs
+++ b/src/action_install.rs
@@ -37,8 +37,7 @@ pub fn install(targets: &[String], dirs: &RuaDirs, is_offline: bool, asdeps: boo
 		);
 		std::process::exit(1)
 	}
-
-	show_install_summary(&pacman_deps, &split_to_depth);
+	show_install_summary(&targets[0], &pacman_deps, &split_to_depth);
 	for pkgbase in split_to_pkgbase.values().collect::<HashSet<_>>() {
 		let dir = dirs.review_dir(pkgbase);
 		fs::create_dir_all(&dir).unwrap_or_else(|err| {
@@ -50,15 +49,30 @@ pub fn install(targets: &[String], dirs: &RuaDirs, is_offline: bool, asdeps: boo
 	install_all(dirs, split_to_depth, split_to_pkgbase, is_offline, asdeps);
 }
 
-fn show_install_summary(pacman_deps: &IndexSet<String>, aur_packages: &IndexMap<String, i32>) {
+fn show_install_summary(
+	pkg_name: &String,
+	pacman_deps: &IndexSet<String>,
+	aur_packages: &IndexMap<String, i32>,
+) {
 	if pacman_deps.len() + aur_packages.len() == 1 {
 		return;
 	}
 	if !pacman_deps.is_empty() {
 		eprintln!("\nIn order to install all targets, the following pacman packages will need to be installed:");
+		eprintln!("\n{}", pkg_name);
 		eprintln!(
 			"{}",
-			pacman_deps.iter().map(|s| format!("  {}", s)).join("\n")
+			pacman_deps
+				.iter()
+				.enumerate()
+				.map(|(i, s)| {
+					if i < pacman_deps.len() - 1 {
+						format!(" ├── {}", s)
+					} else {
+						format!(" └── {}", s)
+					}
+				})
+				.join("\n")
 		);
 	};
 	eprintln!("\nAnd the following AUR packages will need to be built and installed:");


### PR DESCRIPTION
Implemented a tree-view for the pacman and AUR dependencies.

It looks like this:
```
In order to install all targets, the following pacman packages will need to be installed:

freecad
 ├── boost
 ├── eigen
 ├── gcc-fortran
 ├── swig
 ├── xerces-c
 ├── cmake
 ├── python-shiboken2
 ├── pyside2
 ├── shiboken2
 ├── opencascade
 ├── libspnav
 ├── netcdf
 ├── jsoncpp
 ├── python-pyside2
 ├── python-matplotlib
 ├── pyside2-tools
 ├── mercurial
 ├── doxygen
 ├── hdf5
 └── tk

And the following AUR packages will need to be built and installed:
freecad
├── python-pivy
└── med
     └── soqt
          └── coin
Proceed? [O]=ok, Ctrl-C=abort. 
```

There are two codes that provide the same solution. But the thing is:

1st code is quite ugly compared to the second one, but it works great without any failures.
2nd code is much better but fails due to a zipped iterator that finnishes before the original one.
(I can correct that by adding an element) but I think there has to be a better way.