### PR TITLE
fix #102

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RUA is a build tool for ArchLinux, AUR. Its features:
 
 ## Install dependencies
 ```sh
-sudo pacman -S --needed git base-devel bubblewrap-suid lz shellcheck cargo
+sudo pacman -S --needed git base-devel bubblewrap-suid xz shellcheck cargo
 ```
 
 


### PR DESCRIPTION
fixes #102 
by changing non-existent `lz` dependency to `xz`, which is the one listed on the aur page