### PR TITLE
Fix a panic when moving tarballs across storage devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ term_size = "0.3.1"
 uname = "0.1.1"
 users = "0.9.1"
 xz2 = "0.1.6"
+libc = "0.2.66"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
I have `$XDG_CACHE_HOME` and `$XDG_DATA_HOME` on different disks, which would trip up `rua`:
```
Invalid cross-device link (os error 18)', src/action_install.rs:232:13
```