### PR TITLE
Respect makepkg config files in addition to environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cargo check --verbose --all
   - cargo clippy --all-targets --all-features -- -D warnings
   - cargo fmt --all -- --check
-  - shellcheck -e SC1090 res/wrap.sh  # exclude non-constant sourcing that shellcheck cannot check
+  - shellcheck -e SC1090 res/*.sh  # exclude non-constant sourcing that shellcheck cannot check
 
 if: tag IS blank  # do not build tags, only commits
 

--- a/res/print_makepkg_config.sh
+++ b/res/print_makepkg_config.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+# config.sh is a publicly exposed utility library:
+# https://git.archlinux.org/pacman.git/commit/scripts/libmakepkg/util/config.sh.in?id=a00615bfdad628299352b94e0f44d211a758fd17
+source "${LIBRARY:-/usr/share/makepkg}/util/config.sh";
+
+load_makepkg_config;
+
+# config entries which can be overriden with environment variables; taken from util/config.sh
+for var in PKGDEST SRCDEST SRCPKGDEST LOGDEST BUILDDIR PKGEXT SRCEXT GPGKEY PACKAGER CARCH; do
+	[[ -v $var ]] && printf "%s=%s\0" "$var" "${!var}";
+done

--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -2,7 +2,7 @@ use crate::action_install;
 use crate::aur_rpc_utils;
 use crate::pacman;
 use crate::print_package_table;
-use crate::rua_files;
+use crate::rua_environment::RuaEnv;
 use crate::terminal_util;
 use alpm::Version;
 use colored::*;
@@ -23,7 +23,7 @@ fn pkg_is_devel(name: &str) -> bool {
 	RE.is_match(name)
 }
 
-pub fn upgrade(devel: bool, printonly: bool) {
+pub fn upgrade(rua_env: &RuaEnv, devel: bool, printonly: bool) {
 	let alpm = pacman::create_alpm();
 	let pkg_cache = alpm
 		.localdb()
@@ -93,13 +93,12 @@ pub fn upgrade(devel: bool, printonly: bool) {
 		} else {
 			print_outdated(&outdated, &unexistent);
 			eprintln!();
-			let dirs = rua_files::RuaDirs::new();
 			loop {
 				eprint!("Do you wish to upgrade them? [O]=ok, [X]=exit. ");
 				let string = terminal_util::read_line_lowercase();
 				if &string == "o" {
 					let outdated: Vec<String> = outdated.iter().map(|o| o.0.to_string()).collect();
-					action_install::install(&outdated, &dirs, false, true);
+					action_install::install(&outdated, &rua_env, false, true);
 					break;
 				} else if &string == "x" {
 					break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use structopt::StructOpt;
 
 fn main() {
 	let cli_args: CliArgs = CliArgs::from_args();
-	rua_environment::prepare_environment(&cli_args);
+	let rua_env = rua_environment::prepare_environment(&cli_args);
 	match &cli_args.action {
 		Action::Info { ref target } => {
 			info(target, false).unwrap();
@@ -39,16 +39,14 @@ fn main() {
 			offline,
 			target,
 		} => {
-			let dirs = rua_files::RuaDirs::new();
-			action_install::install(&target, &dirs, *offline, *asdeps);
+			action_install::install(&target, &rua_env, *offline, *asdeps);
 		}
 		Action::Builddir {
 			offline,
 			force,
 			target,
 		} => {
-			let dirs = rua_files::RuaDirs::new();
-			action_builddir::action_builddir(target, &dirs, *offline, *force);
+			action_builddir::action_builddir(target, &rua_env, *offline, *force);
 		}
 		Action::Search { target } => action_search::action_search(target),
 		Action::Shellcheck { target } => {
@@ -68,7 +66,7 @@ fn main() {
 			eprintln!("Finished checking package: {:?}", target);
 		}
 		Action::Upgrade { devel, printonly } => {
-			action_upgrade::upgrade(*devel, *printonly);
+			action_upgrade::upgrade(&rua_env, *devel, *printonly);
 		}
 	};
 }

--- a/src/rua_environment.rs
+++ b/src/rua_environment.rs
@@ -1,11 +1,19 @@
 use crate::cli_args;
 use crate::cli_args::CLIColorType;
 use crate::cli_args::CliArgs;
+use crate::rua_files::RuaDirs;
 use chrono::Utc;
+use colored::Colorize;
 use env_logger::Env;
 use log::debug;
 use std::env;
 use std::io::Write;
+use std::process::Command;
+
+pub struct RuaEnv {
+	pub dirs: RuaDirs,
+	pub pkgext: String,
+}
 
 pub fn set_env_if_not_set(key: &str, value: &str) {
 	if env::var_os(key).is_none() {
@@ -14,7 +22,7 @@ pub fn set_env_if_not_set(key: &str, value: &str) {
 }
 
 // sets environment and other things applicable to all RUA commands
-pub fn prepare_environment(config: &CliArgs) {
+pub fn prepare_environment(config: &CliArgs) -> RuaEnv {
 	env_logger::Builder::from_env(Env::default().filter_or("LOG_LEVEL", "info"))
 		.format(|buf, record| {
 			writeln!(
@@ -49,51 +57,59 @@ pub fn prepare_environment(config: &CliArgs) {
 		env!("CARGO_PKG_NAME"),
 		env!("CARGO_PKG_VERSION")
 	);
-	assert!(
-		env::var_os("PKGDEST").is_none(),
-		"Cannot work with PKGDEST environment being set. Please run RUA without it"
-	);
-	env::set_var("PKGDEST", "/dev/null"); // make sure it's overridden later
-	assert!(
-		env::var_os("SRCDEST").is_none(),
-		"Cannot work with SRCDEST environment being set. Please run RUA without it"
-	);
-	env::set_var("SRCDEST", "/dev/null"); // make sure it's overridden later
-	assert!(
-		env::var_os("SRCPKGDEST").is_none(),
-		"Cannot work with SRCPKGDEST environment being set. Please run RUA without it"
-	);
-	env::set_var("SRCPKGDEST", "/dev/null"); // make sure it's overridden later
-	assert!(
-		env::var_os("LOGDEST").is_none(),
-		"Cannot work with LOGDEST environment being set. Please run RUA without it"
-	);
-	env::set_var("LOGDEST", "/dev/null"); // make sure it's overridden later
-	assert!(
-		env::var_os("BUILDDIR").is_none(),
-		"Cannot work with BUILDDIR environment being set. Please run RUA without it"
-	);
-	env::set_var("BUILDDIR", "/dev/null"); // make sure it's overridden later
-	if let Some(extension) = std::env::var_os("PKGEXT") {
-		assert!(
-			extension == ".pkg.tar"
-				|| extension == ".pkg.tar.xz"
-				|| extension == ".pkg.tar.lzma"
-				|| extension == ".pkg.tar.gz"
-				|| extension == ".pkg.tar.gzip"
-				|| extension == ".pkg.tar.zst"
-				|| extension == ".pkg.tar.zstd",
-			"PKGEXT environment is set to an incompatible value. \
-			 Only .pkg.tar or .pkg.tar.xz or .pkg.tar.gz or .pkg.tar.zst archives are supported for now.\
-			 RUA needs those extensions to look inside the archives for 'tar_check' analysis."
-		);
-	} else {
-		env::set_var("PKGEXT", ".pkg.tar.xz");
-	};
-}
 
-pub fn extension() -> String {
-	std::env::var("PKGEXT").expect("Internal error: variable PKGEXT is unset")
+	let dirs = RuaDirs::new();
+	let mut pkgext = None;
+
+	let config = Command::new(&dirs.makepkg_config_loader)
+		.output()
+		.unwrap_or_else(|e| panic!("Internal error: failed to run makepkg config loader: {}", e))
+		.stdout;
+	let config = String::from_utf8(config).expect("makepkg config contains non-UTF-8 data");
+
+	// format: `VAR=VALUE\0`
+	let config_entries = config.split_terminator('\0').map(|line| {
+		let sep_pos = line.find('=').expect("Malformed config loader output");
+		(&line[..sep_pos], &line[sep_pos + 1..])
+	});
+
+	// config entries won't appear here unless set
+	for (var, value) in config_entries {
+		debug!("makepkg option: {} = {:?}", var, value);
+
+		match var {
+			"PKGDEST" | "SRCDEST" | "SRCPKGDEST" | "LOGDEST" | "BUILDDIR" => {
+				let warn = "WARNING".yellow();
+				eprintln!("{}: custom ${} location is not supported.", warn, var);
+			}
+
+			"PKGEXT" => match value {
+				".pkg.tar" | ".pkg.tar.xz" | ".pkg.tar.lzma" | ".pkg.tar.gz" | ".pkg.tar.gzip"
+				| ".pkg.tar.zst" | ".pkg.tar.zstd" => {
+					pkgext = Some(value.to_owned());
+				}
+
+				_ => panic!(
+					"$PKGEXT is set to an unsupported value: {:?}. \
+					Only .pkg.tar or .pkg.tar.xz or .pkg.tar.gz or .pkg.tar.zst archives are \
+					allowed for now. RUA needs those extensions to look inside the archives for \
+					'tar_check' analysis.",
+					value
+				),
+			},
+
+			_ => {}
+		}
+	}
+
+	for &var in &["PKGDEST", "SRCDEST", "SRCPKGDEST", "LOGDEST", "BUILDDIR"] {
+		env::set_var(var, "/dev/null"); // make sure we override it later
+	}
+
+	RuaEnv {
+		dirs,
+		pkgext: pkgext.expect("Internal error: no $PKGEXT entry in makepkg configuration?!"),
+	}
 }
 
 pub fn sudo_command() -> String {

--- a/src/rua_files.rs
+++ b/src/rua_files.rs
@@ -21,6 +21,8 @@ pub struct RuaDirs {
 	global_checked_tars_dir: PathBuf,
 	/// Script used to wrap `makepkg` and related commands
 	pub wrapper_bwrap_script: PathBuf,
+	/// Script used to read `makepkg` config
+	pub makepkg_config_loader: PathBuf,
 	/// Global lock to prevent concurrent access to project dirs
 	_global_lock: File,
 }
@@ -55,6 +57,10 @@ impl RuaDirs {
 			dirs.config_dir().join(seccomp_path).to_str().unwrap(),
 		);
 		overwrite_script(&dirs.config_dir().join(WRAP_SCRIPT_PATH), WRAP_SH);
+		overwrite_script(
+			&dirs.config_dir().join(MAKEPKG_CONFIG_LOADER_PATH),
+			CONFIG_LOADER,
+		);
 		ensure_script(
 			&dirs.config_dir().join(".system/wrap_args.sh.example"),
 			WRAP_ARGS_EXAMPLE,
@@ -83,6 +89,7 @@ impl RuaDirs {
 			global_review_dir: dirs.config_dir().join("pkg"),
 			global_checked_tars_dir,
 			wrapper_bwrap_script: dirs.config_dir().join(WRAP_SCRIPT_PATH),
+			makepkg_config_loader: dirs.config_dir().join(MAKEPKG_CONFIG_LOADER_PATH),
 			_global_lock: locked_file,
 		}
 	}
@@ -161,5 +168,7 @@ pub const SECCOMP_I686: &[u8] = include_bytes!("../res/seccomp-i686.bpf");
 pub const SECCOMP_X86_64: &[u8] = include_bytes!("../res/seccomp-x86_64.bpf");
 pub const WRAP_SH: &[u8] = include_bytes!("../res/wrap.sh");
 pub const WRAP_ARGS_EXAMPLE: &[u8] = include_bytes!("../res/wrap_args.sh.example");
+pub const CONFIG_LOADER: &[u8] = include_bytes!("../res/print_makepkg_config.sh");
 
 pub const WRAP_SCRIPT_PATH: &str = ".system/wrap.sh";
+pub const MAKEPKG_CONFIG_LOADER_PATH: &str = ".system/print_makepkg_config.sh";


### PR DESCRIPTION
Previously, if set only e.g. in `/etc/makepkg.conf`, options
like `PKGEXT` were ignored and defaults were used instead.

Unfortunately, since `makepkg` configuration files are valid
scripts, reading them involves shelling out. Non-ideal, but I
feel that ignoring them is strictly worse.