### PR TITLE
Add --ignore option to upgrade action

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ RUA is a build tool for ArchLinux, AUR. Its features:
 
 `rua install xcalib`  # install or upgrade a package
 
-`rua upgrade`  # upgrade all AUR packages. You can selectively ignore packages by adding them to `IgnorePkg` in `pacman.conf` (same as with non-AUR packages and `pacman`). You can upgrade only specific packages with `rua install A B C`.
+`rua upgrade`  # upgrade all AUR packages. You can selectively ignore packages by using `--ignore` or adding them to `IgnorePkg` in `pacman.conf` (same as with non-AUR packages and `pacman`). You can upgrade only specific packages with `rua install A B C`.
 
 `rua shellcheck path/to/my/PKGBUILD`  # run `shellcheck` on a PKGBUILD, discovering potential problems with the build instruction. Takes care of PKGBUILD-specific variables.
 

--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -22,7 +22,7 @@ fn pkg_is_devel(name: &str) -> bool {
 	RE.is_match(name)
 }
 
-pub fn upgrade_printonly(devel: bool, ignored:&HashSet<String>) {
+pub fn upgrade_printonly(devel: bool, ignored:&HashSet<&str>) {
 	let alpm = pacman::create_alpm();
 	let (outdated, unexistent) = calculate_upgrade(&alpm, devel, ignored);
 
@@ -38,7 +38,7 @@ pub fn upgrade_printonly(devel: bool, ignored:&HashSet<String>) {
 	}
 }
 
-pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<String>) {
+pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>) {
 	let alpm = pacman::create_alpm();
 	let (outdated, unexistent) = calculate_upgrade(&alpm, devel, ignored);
 
@@ -64,7 +64,7 @@ pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<String>
 type OutdatedPkgs<'pkgs> = Vec<(&'pkgs str, String, String)>;
 type ForeignPkgs<'pkgs> = Vec<(&'pkgs str, String)>;
 
-fn calculate_upgrade<'pkgs>(alpm: &'pkgs alpm::Alpm, devel: bool, locally_ignored_packages: &HashSet<String>) -> (OutdatedPkgs<'pkgs>, ForeignPkgs<'pkgs>) {
+fn calculate_upgrade<'pkgs>(alpm: &'pkgs alpm::Alpm, devel: bool, locally_ignored_packages: &HashSet<&str>) -> (OutdatedPkgs<'pkgs>, ForeignPkgs<'pkgs>) {
 	let pkg_cache = alpm
 		.localdb()
 		.pkgs()

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -107,6 +107,12 @@ Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 			help = "Print the list of outdated packages to stdout, delimited by newline. Don't upgrade anything, don't ask questions (for use in scripts)."
 		)]
 		printonly: bool,
+		#[structopt(
+			long = "ignore",
+			short = "I",
+			help = "Don't upgrade the specified package. Can be used more than once."
+		)]
+		ignored: Vec<String>,
 	},
 }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -109,8 +109,7 @@ Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 		printonly: bool,
 		#[structopt(
 			long = "ignore",
-			short = "I",
-			help = "Don't upgrade the specified package. Can be used more than once."
+			help = "Don't upgrade the specified package(s). Can be used more than once and accepts multiple arguments."
 		)]
 		ignored: Vec<String>,
 	},

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -109,9 +109,9 @@ Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 		printonly: bool,
 		#[structopt(
 			long = "ignore",
-			help = "Don't upgrade the specified package(s). Can be used more than once and accepts multiple arguments."
+			help = "Don't upgrade the specified package(s). Accepts multiple arguments separated by `,`."
 		)]
-		ignored: Vec<String>,
+		ignored: String,
 	},
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use cli_args::Action;
 use cli_args::CliArgs;
 use std::process::exit;
 use structopt::StructOpt;
+use std::collections::HashSet;
 
 fn main() {
 	let cli_args: CliArgs = CliArgs::from_args();
@@ -67,12 +68,13 @@ fn main() {
 			);
 			eprintln!("Finished checking package: {:?}", target);
 		}
-		Action::Upgrade { devel, printonly } => {
+		Action::Upgrade { devel, printonly , ignored} => {
+			let ignored_set=ignored.iter().cloned().collect::<HashSet<String>>();
 			if *printonly {
-				action_upgrade::upgrade_printonly(*devel);
+				action_upgrade::upgrade_printonly(*devel, &ignored_set);
 			} else {
 				let paths = rua_paths::RuaPaths::initialize_paths();
-				action_upgrade::upgrade_real(*devel, &paths);
+				action_upgrade::upgrade_real(*devel, &paths, &ignored_set);
 			}
 		}
 	};

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn main() {
 			eprintln!("Finished checking package: {:?}", target);
 		}
 		Action::Upgrade { devel, printonly , ignored} => {
-			let ignored_set=ignored.iter().cloned().collect::<HashSet<String>>();
+			let ignored_set=ignored.split(',').collect::<HashSet<&str>>();
 			if *printonly {
 				action_upgrade::upgrade_printonly(*devel, &ignored_set);
 			} else {


### PR DESCRIPTION
Fixes #107 by adding a new option to the upgrade command.

The following usages mean the same thing:
```
rua upgrade --ignore a --ignore b
rua upgrade -I a -I b
rua upgrade --ignore a b
rua upgrade -I a b
```
I took `-I` and not `-i` because `-i` already has another meaning in the pacman command (show Information) and this opens up rua to use the same letter for the same feature in the future.

But of course this is only my opinion.