### PR TITLE
Add support for BLAKE2 checksums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,9 +1295,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "srcinfo"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc5714b231447cde0c276ced9f6567c5068c6b48558d09cb004b077a27b4fe2"
+checksum = "a69c538e89460803500fca8d5f54a82f5ae1b3b2fc0661462ee41d8641a3571a"
 
 [[package]]
 name = "stacker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ raur = { version = "3.0.1", default-features = false, features = ["rustls"] }
 regex = "1.3.9"
 rm_rf = "0.6.0"
 ruzstd = "0.2.1"
-srcinfo = "0.3.2"
+srcinfo = "1.0.0"
 structopt = "0.3.18"
 tar = "0.4.30"
 term_size = "0.3.2"

--- a/res/shellcheck-wrapper
+++ b/res/shellcheck-wrapper
@@ -51,6 +51,10 @@ export sha512sums
 export sha512sums_aarch64
 export sha512sums_i686
 export sha512sums_x86_64
+export b2sums
+export b2sums_aarch64
+export b2sums_i686
+export b2sums_x86_64
 export groups
 export backup
 export depends

--- a/src/srcinfo_to_pkgbuild.rs
+++ b/src/srcinfo_to_pkgbuild.rs
@@ -44,6 +44,7 @@ pub fn static_pkgbuild(path: &Path) -> String {
 	push_arrays(&mut pkgbuild, "sha256sums", &srcinfo.base.sha256sums);
 	push_arrays(&mut pkgbuild, "sha384sums", &srcinfo.base.sha384sums);
 	push_arrays(&mut pkgbuild, "sha512sums", &srcinfo.base.sha512sums);
+	push_arrays(&mut pkgbuild, "b2sums", &srcinfo.base.b2sums);
 
 	pkgbuild
 }


### PR DESCRIPTION
Their existence and usage are documented on ArchWiki:
https://wiki.archlinux.org/index.php?title=PKGBUILD&oldid=635970#b2sums

Adding support for them simply involves handling them similarly to the other already supported checksum types (sha1sums, sha256sums, etc.)

srcinfo.rs is updated since the old version didn't support BLAKE2 either

This has two effects:

* When building packages offline ('rua builddir --offline' or  'rua install --offline'), the BLAKE2 checksums are checked instead of ignored.
* No superfluous warnings are emitted on the b2sums variable on 'rua shellcheck'  on PKGBUILDs with BLAKE2 checksums, such as this one (Boost):  https://raw.githubusercontent.com/archlinux/svntogit-packages/41c5d32f4ff454ddfca19fcb4a8314594df453f6/trunk/PKGBUILD
