### PR TITLE
Add toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
This sets the default toolchain to stable without having to set an env
var in the pkgbuild.