### PR TITLE
FEATURE: Document ccache usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ RUA will thus interrupt you 3 times, not 7 as if it would be plainly recursive. 
 * Unless you explicitly enable it, builds do not share user home (~). This may result in maven/npm/cargo/whatever dependencies re-downloading with each build. See [safety](#safety) section below on how to whitelist certain directories.
 * Environment variables "PKGDEST" and "BUILDDIR" of makepkg.conf are not supported. Packages are built in isolation from each other, artifacts are stored in standard locations of this tool.
 * Due of safety restrictions, [X11 access might not work](./docs/x11access.md) during build.
+* Also due to safety restrictions, [ccache usage will fail](docs/ccache.md) during build.
 * Due to a [bug in fakeroot](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=909727), creation of root-owned packages inside PKGBUILD-s `package()` does not work. This happens when archives are extracted in `package()` function. Doing it in `prepare()` or giving a key like `tar --no-same-owner` is the work-around.
 
 

--- a/docs/ccache.md
+++ b/docs/ccache.md
@@ -1,0 +1,29 @@
+## Context
+
+This is about using your user's `ccache` from inside a RUA sandbox.
+If you configure `makepkg` to use `ccache` as described in [ArchWiki](https://wiki.archlinux.org/title/Ccache#Enable_ccache_for_makepkg),
+this will fail with error messages like:
+
+```
+ccache: error: Failed to create temporary file for /run/user/1000/ccache-tmp/tmp.cpp_stdout.zdMorR: Read-only file system
+ccache: error: Failed to create temporary file for /run/user/1000/ccache-tmp/tmp.cpp_stdout.A7CGmu: Read-only file system
+ccache: error: Failed to create temporary file for /run/user/1000/ccache-tmp/tmp.cpp_stdout.hAwjZX: Read-only file system
+```
+
+This is intentional, as no program running in the sandbox is allowed to have access to `/run/user/1000`.
+
+On top of that, even if `ccache` would have access to this folder, the cache would be lost after the package was built since `ccache` has no access to the user's `ccache` folder in `~/.ccache`.
+
+## What to do?
+
+You can work around the issue by
+
+1. giving `ccache` access to your `~/.ccache` folder. In theory you can attach any local foder to `~/.ccache` in the sandbox, but for simplicity it is assumed that your `ccache` folder in in your home directory.
+2. asking `ccache` to use a different temporary directory. As `/tmp` is created only for this sandbox, we simply choose a folder below.
+
+In order to implement the aforementioned changes, all you need to do is create `~/.config/rua/wrap_args.d/ccache.sh` with the following content:
+
+```
+wrap_args+=(--bind-try ~/.ccache ~/.ccache)
+export CCACHE_TEMPDIR=/tmp/ccache
+```


### PR DESCRIPTION
I just figured out how to use `ccache` with `rua`.  As I didn't find an issue asking about it or anyone having ever tried it, I thought it might be worthwhile to create some documentation on the subject.

What would be the correct place to link the documentation so that it can be found?  EDIT: Linked it to main `README.md`