### PR TITLE
Add colors to review menu

### DIFF
--- a/src/reviewing.rs
+++ b/src/reviewing.rs
@@ -4,6 +4,7 @@ use crate::terminal_util;
 use crate::wrapped;
 use log::debug;
 use std::path::Path;
+use colored::Colorize;
 
 pub fn review_repo(dir: &Path, pkgbase: &str, rua_paths: &RuaPaths) {
 	let mut dir_contents = dir.read_dir().unwrap_or_else(|err| {
@@ -43,22 +44,22 @@ pub fn review_repo(dir: &Path, pkgbase: &str, rua_paths: &RuaPaths) {
 		let is_upstream_merged = git_utils::is_upstream_merged(&dir);
 		let identical_to_upstream = is_upstream_merged && git_utils::identical_to_upstream(dir);
 		if is_upstream_merged {
-			eprint!("[S]=run shellcheck on PKGBUILD, ");
+			eprint!("{}{}, ", "[S]".bold().green(), "=run shellcheck on PKGBUILD".green());
 			if identical_to_upstream {
-				eprint!("[D]=(identical to upstream, empty diff), ");
+				eprint!("{}, ", "[D]=(identical to upstream, empty diff)".dimmed());
 			} else {
-				eprint!("[D]=view your changes, ");
+				eprint!("{}{}, ", "[D]".bold().green(), "=view your changes".green());
 			};
 		} else {
-			eprint!("[D]=view upstream changes since your last review, ");
-			eprint!("[M]=accept/merge upstream changes, ");
-			eprint!("[S]=(shellcheck not available until you merge), ");
+			eprint!("{}{}, ", "[D]".bold().green(), "=view upstream changes since your last review".green());
+			eprint!("{}{}, ", "[M]".bold().yellow(), "=accept/merge upstream changes".yellow());
+			eprint!("{}, ", "[S]=(shellcheck not available until you merge)".dimmed());
 		}
-		eprint!("[T]=run shell to edit/inspect, ");
+		eprint!("{}{}, ", "[T]".bold().cyan(), "=run shell to edit/inspect".cyan());
 		if is_upstream_merged {
-			eprint!("[O]=ok, use package. ");
+			eprint!("{}{}. ", "[O]".bold().red(), "=ok, use package".red());
 		} else {
-			eprint!("[O]=(cannot use the package until you merge) ");
+			eprint!("{}", "[O]=(cannot use the package until you merge) ".dimmed());
 		}
 		let user_input = terminal_util::read_line_lowercase();
 


### PR DESCRIPTION
With colors it's much easier to tell, where one menu option ends and the next one begins.

The color scheme is based on a simple "traffic lights" concept:
* green is safe (shellcheck/diff)
* red may be dangerous (use package)
* yellow is in between (merge)

Additionally:
* "run terminal" is cyan, to distinguish it from other options
* inactive options appear gray.

In my testing it works well with both white and black terminal background.