### PR TITLE
Add assume-installed #106

### DIFF
--- a/src/action_builddir.rs
+++ b/src/action_builddir.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 /// Build and install a package, see `crate::cli_args::Action::Builddir` for details
-pub fn action_builddir(dir: &Option<PathBuf>, rua_paths: &RuaPaths, offline: bool, force: bool) {
+pub fn action_builddir(dir: &Option<PathBuf>, rua_paths: &RuaPaths, offline: bool, force: bool, no_deps: bool) {
 	// Set `.` as default dir in case no build directory is provided.
 	let dir = match dir {
 		Some(path) => path,
@@ -18,7 +18,7 @@ pub fn action_builddir(dir: &Option<PathBuf>, rua_paths: &RuaPaths, offline: boo
 	let dir_str = dir
 		.to_str()
 		.unwrap_or_else(|| panic!("{}:{} Cannot parse CLI target directory", file!(), line!()));
-	wrapped::build_directory(dir_str, rua_paths, offline, force);
+	wrapped::build_directory(dir_str, rua_paths, offline, force, no_deps);
 
 	let srcinfo = wrapped::generate_srcinfo(dir_str, rua_paths).expect("Failed to obtain SRCINFO");
 	let ver = srcinfo.version();

--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -45,7 +45,7 @@ pub fn upgrade_printonly(devel: bool, ignored: &HashSet<&str>) {
 	}
 }
 
-pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>) {
+pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>, exclude: &Vec<&str>) {
 	let alpm = new_alpm_wrapper();
 	let (outdated, nonexistent) =
 		calculate_upgrade(&*alpm, devel, ignored).expect("calculating upgrade failed");
@@ -70,7 +70,7 @@ pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>) 
 			let user_input = terminal_util::read_line_lowercase();
 			if &user_input == "o" {
 				let outdated: Vec<String> = outdated.iter().map(|o| o.0.to_string()).collect();
-				action_install::install(&outdated, rua_paths, false, true);
+				action_install::install(&outdated, rua_paths, false, true, exclude);
 				break;
 			} else if &user_input == "x" {
 				break;

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -69,6 +69,8 @@ Sources are downloaded using .SRCINFO only"
 		offline: bool,
 		#[structopt(help = "Target package", multiple = true, required = true)]
 		target: Vec<String>,
+                #[structopt(help = "Exclude package(s). Can take multiple values seperated by `,`.")]
+                exclude: Option<String>,
 	},
 	#[structopt(
 		about = "Search for packages by name or description. If multiple keywords are used, all of them must match."
@@ -114,6 +116,8 @@ Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 			help = "Don't upgrade the specified package(s). Accepts multiple arguments separated by `,`."
 		)]
 		ignored: Option<String>,
+                #[structopt(help = "Exclude package(s). Can take multiple values seperated by `,`.")]
+                exclude: Option<String>,
 	},
 }
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -69,7 +69,10 @@ Sources are downloaded using .SRCINFO only"
 		offline: bool,
 		#[structopt(help = "Target package", multiple = true, required = true)]
 		target: Vec<String>,
-                #[structopt(help = "Exclude package(s). Can take multiple values seperated by `,`.")]
+                #[structopt(
+                    help = "Exclude package(s) from dependency check. Can take multiple values seperated by `,`.",
+                    long = "assume-installed"
+                )]
                 exclude: Option<String>,
 	},
 	#[structopt(
@@ -116,7 +119,10 @@ Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 			help = "Don't upgrade the specified package(s). Accepts multiple arguments separated by `,`."
 		)]
 		ignored: Option<String>,
-                #[structopt(help = "Exclude package(s). Can take multiple values seperated by `,`.")]
+                #[structopt(
+                    help = "Exclude package(s) from dependency check. Can take multiple values seperated by `,`.",
+                    long = "assume-installed"
+                )]
                 exclude: Option<String>,
 	},
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,13 @@ fn main() {
 			asdeps,
 			offline,
 			target,
+                        exclude,
 		} => {
+                        let exclude = exclude.iter()
+                            .flat_map(|i| i.split(','))
+                            .collect::<Vec<&str>>();
 			let paths = rua_paths::RuaPaths::initialize_paths();
-			action_install::install(target, &paths, *offline, *asdeps);
+			action_install::install(target, &paths, *offline, *asdeps, &exclude);
 		}
 		Action::Builddir {
 			offline,
@@ -51,7 +55,7 @@ fn main() {
 			target,
 		} => {
 			let paths = rua_paths::RuaPaths::initialize_paths();
-			action_builddir::action_builddir(target, &paths, *offline, *force);
+			action_builddir::action_builddir(target, &paths, *offline, *force, false);
 		}
 		Action::Search { target } => action_search::action_search(target),
 		Action::Shellcheck { target } => {
@@ -74,16 +78,20 @@ fn main() {
 			devel,
 			printonly,
 			ignored,
+                        exclude,
 		} => {
 			let ignored_set = ignored
 				.iter()
 				.flat_map(|i| i.split(','))
 				.collect::<HashSet<&str>>();
+                        let exclude = exclude.iter()
+                            .flat_map(|i| i.split(','))
+                            .collect::<Vec<&str>>();
 			if *printonly {
 				action_upgrade::upgrade_printonly(*devel, &ignored_set);
 			} else {
 				let paths = rua_paths::RuaPaths::initialize_paths();
-				action_upgrade::upgrade_real(*devel, &paths, &ignored_set);
+				action_upgrade::upgrade_real(*devel, &paths, &ignored_set, &exclude);
 			}
 		}
 	};

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -125,15 +125,15 @@ fn build_local(dir: &str, rua_paths: &RuaPaths, offline: bool, force: bool, no_d
 	let mut command = jail_for_makepkg(rua_paths, dir, dir);
 	if offline {
 		command.arg("--unshare-net");
-	}
-        if no_deps {
-            command.arg("-d");
-        }
+	} 
 	command.args(&["--bind", dir, dir]).arg("makepkg");
 	command.env("FAKEROOTDONTTRYCHOWN", "true");
 	if force {
 		command.arg("--force");
 	}
+        if no_deps {
+            command.arg("-d");
+        }
 	let command = command.status().unwrap_or_else(|e| {
 		panic!(
 			"Failed to execute ~/.config/rua/.system/security-wrapper.sh, {}",


### PR DESCRIPTION
Added the ability to specify packages that should be filtered out from the pacman_deps list. makepkg doesn't have a --assume-installed equivalent so if a filter is provided by the user then nodeps is added to the makepkg arguments list.

First time contributing to a rust project. Any feedback is welcome.