### PR TITLE
Enhancement #180 - option to automate build prompts

### DIFF
--- a/src/action_builddir.rs
+++ b/src/action_builddir.rs
@@ -6,7 +6,13 @@ use std::path::Path;
 use std::path::PathBuf;
 
 /// Build and install a package, see `crate::cli_args::Action::Builddir` for details
-pub fn action_builddir(dir: &Option<PathBuf>, rua_paths: &RuaPaths, offline: bool, force: bool) {
+pub fn action_builddir(
+	dir: &Option<PathBuf>,
+	rua_paths: &RuaPaths,
+	offline: bool,
+	force: bool,
+	autobuild: bool,
+) {
 	// Set `.` as default dir in case no build directory is provided.
 	let dir = match dir {
 		Some(path) => path,
@@ -39,9 +45,9 @@ pub fn action_builddir(dir: &Option<PathBuf>, rua_paths: &RuaPaths, offline: boo
 
 	for (_, file) in &packages {
 		let file_str = file.to_str().expect("Builddir target has unvalid UTF-8");
-		tar_check::tar_check(file, file_str).ok();
+		tar_check::tar_check(file, file_str, false).ok();
 	}
 	eprintln!("Package built and checked.");
 
-	pacman::ensure_aur_packages_installed(packages, false);
+	pacman::ensure_aur_packages_installed(packages, false, autobuild);
 }

--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -45,7 +45,7 @@ pub fn upgrade_printonly(devel: bool, ignored: &HashSet<&str>) {
 	}
 }
 
-pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>) {
+pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>, autobuild: bool) {
 	let alpm = new_alpm_wrapper();
 	let (outdated, nonexistent) =
 		calculate_upgrade(&*alpm, devel, ignored).expect("calculating upgrade failed");
@@ -67,10 +67,15 @@ pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>) 
 		eprintln!();
 		loop {
 			eprint!("Do you wish to upgrade them? [O]=ok, [X]=exit. ");
-			let user_input = terminal_util::read_line_lowercase();
+			let user_input = if autobuild {
+				eprintln!("\n{} {}", "Autobuild:".italic(), "[O]".italic());
+				"o".to_string()
+			} else {
+				terminal_util::read_line_lowercase()
+			};
 			if &user_input == "o" {
 				let outdated: Vec<String> = outdated.iter().map(|o| o.0.to_string()).collect();
-				action_install::install(&outdated, rua_paths, false, true);
+				action_install::install(&outdated, rua_paths, false, true, autobuild);
 				break;
 			} else if &user_input == "x" {
 				break;

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -50,6 +50,8 @@ Sources are downloaded using .SRCINFO only"
 			help = "Target directory. Defaults to current directory '.' if not specified."
 		)]
 		target: Option<PathBuf>,
+		#[structopt(short = "b", long = "auto-build", help = "Automate build promps")]
+		autobuild: bool,
 	},
 	#[structopt(about = "Show package information")]
 	Info {
@@ -69,6 +71,12 @@ Sources are downloaded using .SRCINFO only"
 		offline: bool,
 		#[structopt(help = "Target package", multiple = true, required = true)]
 		target: Vec<String>,
+		#[structopt(
+			short = "b",
+			long = "auto-build",
+			help = "Automate build promps (doesn't apply --noconfirm to pacman commands)"
+		)]
+		autobuild: bool,
 	},
 	#[structopt(
 		about = "Search for packages by name or description. If multiple keywords are used, all of them must match."
@@ -114,6 +122,12 @@ Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 			help = "Don't upgrade the specified package(s). Accepts multiple arguments separated by `,`."
 		)]
 		ignored: Option<String>,
+		#[structopt(
+			short = "b",
+			long = "auto-build",
+			help = "Automate build promps (doesn't apply --noconfirm to pacman commands)"
+		)]
+		autobuild: bool,
 	},
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,17 +41,19 @@ fn main() {
 			asdeps,
 			offline,
 			target,
+			autobuild,
 		} => {
 			let paths = rua_paths::RuaPaths::initialize_paths();
-			action_install::install(target, &paths, *offline, *asdeps);
+			action_install::install(target, &paths, *offline, *asdeps, *autobuild);
 		}
 		Action::Builddir {
 			offline,
 			force,
 			target,
+			autobuild,
 		} => {
 			let paths = rua_paths::RuaPaths::initialize_paths();
-			action_builddir::action_builddir(target, &paths, *offline, *force);
+			action_builddir::action_builddir(target, &paths, *offline, *force, *autobuild);
 		}
 		Action::Search { target } => action_search::action_search(target),
 		Action::Shellcheck { target } => {
@@ -67,6 +69,7 @@ fn main() {
 			tar_check::tar_check_unwrap(
 				target,
 				target.to_str().expect("target is not valid UTF-8"),
+				false,
 			);
 			eprintln!("Finished checking package: {:?}", target);
 		}
@@ -74,6 +77,7 @@ fn main() {
 			devel,
 			printonly,
 			ignored,
+			autobuild,
 		} => {
 			let ignored_set = ignored
 				.iter()
@@ -83,7 +87,7 @@ fn main() {
 				action_upgrade::upgrade_printonly(*devel, &ignored_set);
 			} else {
 				let paths = rua_paths::RuaPaths::initialize_paths();
-				action_upgrade::upgrade_real(*devel, &paths, &ignored_set);
+				action_upgrade::upgrade_real(*devel, &paths, &ignored_set, *autobuild);
 			}
 		}
 	};

--- a/src/pacman.rs
+++ b/src/pacman.rs
@@ -59,10 +59,8 @@ fn ensure_packages_installed(
 				);
 				eprint!("or install manually and enter M when done. ");
 			}
-			attempt += 1;
-
 			let string = if autobuild {
-				if attempt == 1 {
+				if attempt == 0 {
 					eprintln!("\n{} {}", "Autobuild:".italic(), "[S]".italic());
 					"s".to_string()
 				} else {
@@ -76,6 +74,7 @@ fn ensure_packages_installed(
 			} else {
 				terminal_util::read_line_lowercase()
 			};
+			attempt += 1;
 			if string == "s" {
 				let exit_status = Command::new(rua_environment::sudo_command())
 					.arg("pacman")

--- a/src/reviewing.rs
+++ b/src/reviewing.rs
@@ -6,7 +6,7 @@ use colored::Colorize;
 use log::debug;
 use std::path::Path;
 
-pub fn review_repo(dir: &Path, pkgbase: &str, rua_paths: &RuaPaths) {
+pub fn review_repo(dir: &Path, pkgbase: &str, rua_paths: &RuaPaths, autobuild: bool) {
 	let mut dir_contents = dir.read_dir().unwrap_or_else(|err| {
 		panic!(
 			"{}:{} Failed to read directory for reviewing, {}",
@@ -83,8 +83,18 @@ pub fn review_repo(dir: &Path, pkgbase: &str, rua_paths: &RuaPaths) {
 				"[O]=(cannot use the package until you merge) ".dimmed()
 			);
 		}
-		let user_input = terminal_util::read_line_lowercase();
 
+		let user_input = if autobuild {
+			if is_upstream_merged {
+				eprintln!("\n{} {}", "Autobuild:".italic(), "[O]".italic().red());
+				"o".to_string()
+			} else {
+				eprintln!("\n{} {}", "Autobuild:".italic(), "[M]".italic().yellow());
+				"m".to_string()
+			}
+		} else {
+			terminal_util::read_line_lowercase()
+		};
 		if &user_input == "t" {
 			eprintln!("Changes that you make will be merged with upstream updates in future.");
 			eprintln!("Exit the shell with `logout` or Ctrl-D...");

--- a/src/tar_check.rs
+++ b/src/tar_check.rs
@@ -13,27 +13,27 @@ use std::path::PathBuf;
 use tar::*;
 use xz2::read::XzDecoder;
 
-pub fn tar_check_unwrap(tar_file: &Path, file_name: &str) {
-	let result = tar_check(tar_file, file_name);
+pub fn tar_check_unwrap(tar_file: &Path, file_name: &str, autobuild: bool) {
+	let result = tar_check(tar_file, file_name, autobuild);
 	result.unwrap_or_else(|err| {
 		eprintln!("{}", err);
 		std::process::exit(1)
 	})
 }
 
-pub fn tar_check(tar_file: &Path, tar_str: &str) -> Result<(), String> {
+pub fn tar_check(tar_file: &Path, tar_str: &str, autobuild: bool) -> Result<(), String> {
 	let archive = File::open(&tar_file).unwrap_or_else(|_| panic!("cannot open file {}", tar_str));
 	debug!("Checking file {}", tar_str);
 	if tar_str.ends_with(".tar") {
-		tar_check_archive(Archive::new(archive), tar_str);
+		tar_check_archive(Archive::new(archive), tar_str, autobuild);
 		Ok(())
 	} else if tar_str.ends_with(".tar.xz") || tar_str.ends_with(".tar.lzma") {
-		tar_check_archive(Archive::new(XzDecoder::new(archive)), tar_str);
+		tar_check_archive(Archive::new(XzDecoder::new(archive)), tar_str, autobuild);
 		Ok(())
 	} else if tar_str.ends_with(".tar.gz") || tar_str.ends_with(".tar.gzip") {
 		match Decoder::new(archive) {
 			Ok(decoded) => {
-				tar_check_archive(Archive::new(decoded), tar_str);
+				tar_check_archive(Archive::new(decoded), tar_str, autobuild);
 				Ok(())
 			},
 			Err(err) => {
@@ -44,7 +44,7 @@ pub fn tar_check(tar_file: &Path, tar_str: &str) -> Result<(), String> {
 		let mut archive = archive;
 		match StreamingDecoder::new(&mut archive) {
 			Ok(decoder) => {
-				tar_check_archive(Archive::new(decoder), tar_str);
+				tar_check_archive(Archive::new(decoder), tar_str, autobuild);
 				Ok(())
 			},
 			Err(err) => {
@@ -59,7 +59,7 @@ pub fn tar_check(tar_file: &Path, tar_str: &str) -> Result<(), String> {
 	}
 }
 
-fn tar_check_archive<R: Read>(mut archive: Archive<R>, path_str: &str) {
+fn tar_check_archive<R: Read>(mut archive: Archive<R>, path_str: &str, autobuild: bool) {
 	let mut install_file = String::new();
 	let mut all_files = Vec::new();
 	let mut executable_files = Vec::new();
@@ -135,7 +135,12 @@ fn tar_check_archive<R: Read>(mut archive: Archive<R>, path_str: &str) {
 			);
 		};
 		eprint!("{}=ok, proceed. ", "[O]".bold());
-		let string = terminal_util::read_line_lowercase();
+		let string = if autobuild {
+			eprintln!("\n{} {}", "Autobuild:".italic(), "[O]".italic());
+			"o".to_string()
+		} else {
+			terminal_util::read_line_lowercase()
+		};
 		eprintln!();
 		if &string == "s" && !suid_files.is_empty() {
 			for path in &suid_files {


### PR DESCRIPTION
Adds enhancement requested in #180
- adds `--auto-build`/`-b` option to automate rua promps for the `upgrade`, `install` and `builddir` subcommands
- _doesn't_ add `--noconfirm` to pacman commands so user input is still required there (seemed like a step too far but I'd be happy to add it)
- automates build promps:
  - confirm install [O] in `show_install_summary()`
  - confirm upgrade [O] in `upgrade_real()`
  - confirm pacman install [S] in `ensure_packages_installed()` but skips [X] if first attempt fails
  - merge upstream [M]/use package [O] in `review_repo()`
  - skip tarcheck [O] in `tar_check_archive()`
- whenever user input is automated, a message is printed to give the user immediate feedback that an option has been chosen and what the equivalent user input would be
  - the autobuild messages are italicized to distinguish from proceeding output and reduce visual clutter
  - where appropriate the autobuild selection is colorized to match the preceding prompt

![rua-pr](https://user-images.githubusercontent.com/44878819/168523093-eaf15a0c-0279-4fa9-8874-b562f6523bce.png)