### PR TITLE
Do not change install reason during upgrades

### DIFF
--- a/src/action_upgrade.rs
+++ b/src/action_upgrade.rs
@@ -70,7 +70,10 @@ pub fn upgrade_real(devel: bool, rua_paths: &RuaPaths, ignored: &HashSet<&str>) 
 			let user_input = terminal_util::read_line_lowercase();
 			if &user_input == "o" {
 				let outdated: Vec<String> = outdated.iter().map(|o| o.0.to_string()).collect();
-				action_install::install(&outdated, rua_paths, false, true);
+				// Using `false` here means we pass neither `--asdeps` nor `--asexplicit`
+				// to pacman, effectively leaving install reasons untouched.
+				let asdeps = false;
+				action_install::install(&outdated, rua_paths, false, asdeps);
 				break;
 			} else if &user_input == "x" {
 				break;


### PR DESCRIPTION
When upgrading AUR packages `rua` always adds the `--asdeps` switch to the `pacman` command line. That means that packages that were previously installed explicitly most likely end up as orphans because they have no other packages depending on them. This is annoying because it means one needs to run `pacman -D --asexlict <list of upgraded packages>` after every upgrade of AUR packages to keep the install reasons correct and to prevent accidental uninstallation.

This PR changes the behavior during upgrades to not include the `--asdeps` switch which means the install reasons of the upgraded packages stay unchanged.

This should fix #169, but not the related #65, which seems different despite someone having commented that the issues are duplicates of each other.