### PR TITLE
Make colored `git diff` output readable

### DIFF
--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -83,6 +83,7 @@ fn git(dir: &Path, rua_paths: &RuaPaths) -> Command {
 	command.arg("git");
 	command.env("GIT_CONFIG", "/dev/null"); // see `man git-config`
 	command.env("GIT_CONFIG_NOSYSTEM", "1"); // see `man git`
+	command.env("GIT_PAGER", "less -R"); // see `man git-var`
 	command.current_dir(dir);
 	command
 }


### PR DESCRIPTION
When pressing D to "view upstream changes since your last review" raw escape codes like "ESC[32m+ESC[m" were being printed.