### PR TITLE
Fix 'run shell to inspect' failing with 'No such file or directory'

### DIFF
--- a/src/action_install.rs
+++ b/src/action_install.rs
@@ -218,8 +218,12 @@ pub fn check_tars_and_move(name: &str, rua_paths: &RuaPaths, archive_whitelist: 
 	dir_items
 		.retain(|(_, name)| archive_whitelist.contains(&name[..name.len() - common_suffix_length]));
 	trace!("Files filtered for tar checking: {:?}", &dir_items);
-	for (file, file_name) in dir_items.iter() {
-		tar_check::tar_check_unwrap(&file.path(), file_name);
+	for (file, _file_name) in dir_items.iter() {
+		let path = file.path();
+		tar_check::tar_check_unwrap(
+			&path,
+			path.to_str().expect("Non-UTF8 characters in build path"),
+		);
 	}
 	debug!("all package (tar) files checked, moving them");
 	let checked_tars_dir = rua_paths.checked_tars_dir(name);

--- a/src/tar_check.rs
+++ b/src/tar_check.rs
@@ -107,9 +107,13 @@ fn tar_check_archive<R: Read>(mut archive: Archive<R>, path_str: &str) {
 	}
 
 	let has_install = !install_file.is_empty();
+	let display_name = Path::new(path_str)
+		.file_name()
+		.and_then(|p| p.to_str())
+		.unwrap_or(path_str);
 	loop {
 		if suid_files.is_empty() {
-			eprintln!("Package {} has no SUID files.", path_str);
+			eprintln!("Package {} has no SUID files.", display_name);
 		}
 		eprint!("{}=list executable files, ", "[E]".bold());
 		eprint!("{}=list all files, ", "[L]".bold());
@@ -161,7 +165,10 @@ fn tar_check_archive<R: Read>(mut archive: Archive<R>, path_str: &str) {
 			eprintln!("{}", &install_file);
 		} else if &string == "t" {
 			let dir = PathBuf::from(path_str);
-			let dir = dir.parent().unwrap_or_else(|| Path::new("."));
+			let dir = dir
+				.parent()
+				.filter(|p| !p.as_os_str().is_empty())
+				.unwrap_or_else(|| Path::new("."));
 			eprintln!("Exit the shell with `logout` or Ctrl-D...");
 			terminal_util::run_env_command(dir, "SHELL", "bash", &[]);
 		} else if &string == "o" {


### PR DESCRIPTION
Bug: After building a package, pressing T at the tar check screen to run a shell failed with os error 2. The handler derived the shell's working directory from path_str, but in the install flow the caller passed only the archive basename (e.g. package-name.pkg.tar.zst). For a path with no directory component, Path::parent() returns Some(""), so current_dir("") was used and failed.

The fix is to pass in the full_path, and then extract out just the name as needed. Fixes #242