### PR TITLE
Add support for rua upgrade to only upgrade specific packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ RUA is a build tool for ArchLinux, AUR. Its features:
 
 `rua install pinta`  # install or upgrade a package
 
-`rua upgrade`  # upgrade all AUR packages. You can selectively ignore packages by using `--ignore` or adding them to `IgnorePkg` in `pacman.conf` (same as with non-AUR packages and `pacman`). You can upgrade only specific packages with `rua install A B C`.
+`rua upgrade`  # upgrade AUR packages. By default, all packages are upgraded, unless specific packages are given as arguments. You can selectively ignore packages by using `--ignore` or adding them to `IgnorePkg` in `pacman.conf` (same as with non-AUR packages and `pacman`).
 
 `rua shellcheck path/to/my/PKGBUILD`  # run `shellcheck` on a PKGBUILD, discovering potential problems with the build instruction. Takes care of PKGBUILD-specific variables.
 

--- a/src/cli_args.rs
+++ b/src/cli_args.rs
@@ -101,7 +101,7 @@ Sources are downloaded using .SRCINFO only"
 		target: PathBuf,
 	},
 	#[structopt(
-		about = "Upgrade AUR packages. To ignore packages, add them to IgnorePkg in /etc/pacman.conf"
+		about = "Upgrade AUR packages by name, or all packages if package names are not provide"
 	)]
 	Upgrade {
 		#[structopt(
@@ -121,6 +121,11 @@ Supports: git, hg, bzr, svn, cvs, darcs. Currently by suffix only."
 			help = "Don't upgrade the specified package(s). Accepts multiple arguments separated by `,`."
 		)]
 		ignored: Option<String>,
+		#[structopt(
+			help = "Package names to upgrade. If no packages are given, all AUR packages will be upgraded",
+			multiple = true
+		)]
+		packages: Vec<String>,
 	},
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,16 +70,22 @@ fn main() {
 			devel,
 			printonly,
 			ignored,
+			packages,
 		} => {
 			let ignored_set = ignored
 				.iter()
 				.flat_map(|i| i.split(','))
 				.collect::<HashSet<&str>>();
-			if *printonly {
-				action_upgrade::upgrade_printonly(*devel, &ignored_set);
+			let only_packages: HashSet<&str> = packages.iter().map(String::as_str).collect();
+			let result = if *printonly {
+				action_upgrade::upgrade_printonly(*devel, &ignored_set, &only_packages)
 			} else {
 				let paths = rua_paths::RuaPaths::initialize_paths();
-				action_upgrade::upgrade_real(*devel, &paths, &ignored_set);
+				action_upgrade::upgrade_real(*devel, &paths, &ignored_set, &only_packages)
+			};
+			if let Err(e) = result {
+				eprintln!("{}", e);
+				exit(1);
 			}
 		}
 	};


### PR DESCRIPTION
Many times I only want to update a single package. However, the `rua upgrade` functionality requires knowing every package that might be updated, and then ignoring every other one. With this PR, the behavior of `rua upgrade` without arguments remains the same - update all packages. However, if you pass in positional args, then only those packages are updated